### PR TITLE
use AuthBrute mixin more efficiently

### DIFF
--- a/modules/auxiliary/scanner/http/azure_ad_login.rb
+++ b/modules/auxiliary/scanner/http/azure_ad_login.rb
@@ -35,7 +35,7 @@ class MetasploitModule < Msf::Auxiliary
     register_options(
       [
         OptString.new('RHOST', [true, 'The target Azure endpoint', 'autologon.microsoftazuread-sso.com']),
-        OptString.new('DOMAIN', [true, 'The target Azure AD domain', '']),
+        OptString.new('DOMAIN', [true, 'The target Azure AD domain']),
         OptString.new('TARGETURI', [ true, 'The base path to the Azure autologon endpoint', '/winauth/trust/2005/usernamemixed']),
       ]
     )
@@ -56,7 +56,8 @@ class MetasploitModule < Msf::Auxiliary
     credential_data = {
       origin_type: :service,
       module_fullname: fullname,
-      realm: domain,
+      realm_key: Metasploit::Model::Realm::Key::ACTIVE_DIRECTORY_DOMAIN,
+      realm_value: domain,
       username: username,
       private_data: password,
       private_type: :password

--- a/modules/auxiliary/scanner/http/azure_ad_login.rb
+++ b/modules/auxiliary/scanner/http/azure_ad_login.rb
@@ -93,8 +93,8 @@ class MetasploitModule < Msf::Auxiliary
                 <wsu:Expires>#{expires}</wsu:Expires>
             </wsu:Timestamp>
             <wsse:UsernameToken wsu:Id=\"#{username_token}\">
-                <wsse:Username>#{username}@#{domain}</wsse:Username>
-                <wsse:Password>#{password}</wsse:Password>
+                <wsse:Username>#{username.strip.encode(xml: :text)}@#{domain}</wsse:Username>
+                <wsse:Password>#{password.strip.encode(xml: :text)}</wsse:Password>
             </wsse:UsernameToken>
         </wsse:Security>
     </s:Header>

--- a/modules/auxiliary/scanner/http/azure_ad_login.rb
+++ b/modules/auxiliary/scanner/http/azure_ad_login.rb
@@ -7,7 +7,6 @@ class MetasploitModule < Msf::Auxiliary
   include Msf::Auxiliary::Report
   include Msf::Exploit::Remote::HttpClient
   include Msf::Auxiliary::AuthBrute
-  include Msf::Auxiliary::Scanner
 
   def initialize
     super(
@@ -47,7 +46,7 @@ class MetasploitModule < Msf::Auxiliary
                        'BLANK_PASSWORDS', 'RHOSTS')
   end
 
-  def report_login(rhost, rport, domain, username, password)
+  def report_login(domain, username, password)
     # report information, if needed
     service_data = {
       address: rhost,
@@ -72,7 +71,7 @@ class MetasploitModule < Msf::Auxiliary
     create_credential_login(login_data)
   end
 
-  def check_login(rhost, rport, targeturi, domain, username, password)
+  def check_login(targeturi, domain, username, password)
     request_id = SecureRandom.uuid
     url = "https://#{rhost}/#{domain}#{targeturi}"
 
@@ -134,55 +133,35 @@ class MetasploitModule < Msf::Auxiliary
     if xml.xpath('//DesktopSsoToken')[0]
       print_good("Login #{domain}\\#{username}:#{password} is valid!")
       print_good("Desktop SSO Token: #{auth_details}")
-      report_login(rhost, rport, domain, username, password)
+      report_login(domain, username, password)
+      :next_user
     elsif auth_details.start_with?('AADSTS50126') # Valid user but incorrect password
       print_good("Password #{password} is invalid but #{domain}\\#{username} is valid!")
-      report_login(rhost, rport, domain, username, nil)
+      report_login(domain, username, nil)
     elsif auth_details.start_with?('AADSTS50056') # User exists without a password in Azure AD
       print_good("#{domain}\\#{username} is valid but the user does not have a password in Azure AD!")
-      report_login(rhost, rport, domain, username, nil)
+      report_login(domain, username, nil)
+      :next_user
     elsif auth_details.start_with?('AADSTS50076') # User exists, but you need MFA to connect to this resource
       print_good("Login #{domain}\\#{username}:#{password} is valid, but you need MFA to connect to this resource")
-      report_login(rhost, rport, domain, username, password)
+      report_login(domain, username, password)
+      :next_user
     elsif auth_details.start_with?('AADSTS50014') # User exists, but the maximum Pass-through Authentication time was exceeded
       print_good("#{domain}\\#{username} is valid but the maximum pass-through authentication time was exceeded")
-      report_login(rhost, rport, domain, username, nil)
+      report_login(domain, username, nil)
     elsif auth_details.start_with?('AADSTS50034') # User does not exist
       print_error("#{domain}\\#{username} is not a valid user")
     elsif auth_details.start_with?('AADSTS50053') # Account is locked
       print_error('Account is locked, consider taking time before continuuing to scan!')
+      :next_user
     else # Unknown error code
       print_error("Received unknown response with error code: #{auth_details}")
     end
   end
 
-  def check_logins(rhost, rport, targeturi, domain, usernames, passwords)
-    for username in usernames do
-      for password in passwords do
-        check_login(rhost, rport, targeturi, domain,
-                    username.strip.encode(xml: :text), password.strip.encode(xml: :text))
-      end
-    end
-  end
-
   def run
-    # Check whether the username is a file or string, stick either in an array
-    if datastore['USER_FILE']
-      usernames = File.readlines(datastore['USER_FILE'])
-    elsif datastore['USERNAME']
-      usernames = [datastore['USERNAME']]
-    else
-      fail_with(Failure::BadConfig, 'Either USERNAME or USER_FILE must be set')
+    each_user_pass do |cur_user, cur_pass|
+      check_login(datastore['TARGETURI'], datastore['DOMAIN'], cur_user, cur_pass)
     end
-    if datastore['PASS_FILE']
-      passwords = File.readlines(datastore['PASS_FILE'])
-    elsif datastore['PASSWORD']
-      passwords = [datastore['PASSWORD']]
-    else
-      fail_with(Failure::BadConfig, 'Either PASSWORD or PASS_FILE must be set')
-    end
-
-    check_logins(datastore['RHOST'], datastore['RPORT'], datastore['TARGETURI'],
-                 datastore['DOMAIN'], usernames, passwords)
   end
 end

--- a/modules/auxiliary/scanner/http/azure_ad_login.rb
+++ b/modules/auxiliary/scanner/http/azure_ad_login.rb
@@ -48,12 +48,11 @@ class MetasploitModule < Msf::Auxiliary
 
   def report_login(address, domain, username, password)
     # report information, if needed
-    service_data = {
+    service_data = service_details.merge({
       address: address,
-      port: rport,
       service_name: 'Azure AD',
-      protocol: 'http'
-    }
+      workspace_id: myworkspace_id
+    })
     credential_data = {
       origin_type: :service,
       module_fullname: fullname,


### PR DESCRIPTION
Refactors processing to take advantage of the facilities in `Msf::Auxiliary::AuthBrute`.  This shifts the responsibility of evaluating the username and password options and iteration of them into the common library.

By using `each_user_pass` and updating the `check_login` method to return `:next_user` when response values suggest the username will not result in any further useful responses this code also improves the efficiency processing permutations.

Review testing also noted that the host address needed for credential reporting needs to be resolved into an address, this was handled by reporting a `host` that does this resolution using Framework utilities.

XML encoding of username and password guess values is also shifted into the XML object creation to ensure the original value is stored in the credential.

The refactor also relies on the `rhost` and `rport` methods already provided to the module to avoid shadow redefining those values in method signatures.